### PR TITLE
[chg] Dependency from abandoned pycrypto to pycryptodome

### DIFF
--- a/payment_redsys/README.rst
+++ b/payment_redsys/README.rst
@@ -11,10 +11,10 @@ Este módulo añade la opción de pago a través de la pasarela de Redsys.
 Instalación
 ===========
 
-Para utilizar este módulo, necesita la biblioteca `pycrypto
-<https://pypi.python.org/pypi/pycrypto>`_ instalada en su sistema::
+Para utilizar este módulo, necesita la biblioteca `pycryptodome
+<https://pypi.python.org/pypi/pycryptodome>`_ instalada en su sistema::
 
-    pip install pycrypto
+    pip install pycryptodome
 
 Configuración
 =============

--- a/payment_redsys/models/redsys.py
+++ b/payment_redsys/models/redsys.py
@@ -20,7 +20,7 @@ _logger = logging.getLogger(__name__)
 try:
     from Crypto.Cipher import DES3
 except ImportError:
-    _logger.info("Missing dependency (pycrypto). See README.")
+    _logger.info("Missing dependency (pycryptodome). See README.")
 
 
 class AcquirerRedsys(models.Model):
@@ -185,7 +185,9 @@ class AcquirerRedsys(models.Model):
             IV=b'\0\0\0\0\0\0\0\0')
         diff_block = len(order) % 8
         zeros = diff_block and (b'\0' * (8 - diff_block)) or ''
-        key = cipher.encrypt(order + zeros.decode())
+        key = cipher.encrypt(
+            str.encode(order + zeros.decode())
+        )
         if isinstance(params64, str):
             params64 = params64.encode()
         dig = hmac.new(


### PR DESCRIPTION
As pycrypto is abandoned and it is not easily installable in Odoo 11 docker.
I suggest depending on pycryptodome which is a nearly drop in substitute that can be installed with pip in python3 and on Odoo11 docker