### PR TITLE
[16.0][FIX] l10n_es_vat_book: El libro de IVA con los impuestos de IVA soportado no deducible

### DIFF
--- a/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
+++ b/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
@@ -124,6 +124,7 @@
             name="tax_agency_ids"
             eval="[ Command.link(ref('l10n_es_aeat.aeat_tax_agency_spain')) ]"
         />
+        <field name="tax_account_id" ref="l10n_es.account_common_472" />
         <field
             name="tax_tmpl_ids"
             eval="[

--- a/l10n_es_vat_book/report/vat_book_xlsx.py
+++ b/l10n_es_vat_book/report/vat_book_xlsx.py
@@ -328,6 +328,8 @@ class VatNumberXlsx(models.AbstractModel):
         sheet.write("P" + str(row), tax_line.tax_amount)
         if tax_line.tax_id not in self._get_undeductible_taxes(line.vat_book_id):
             sheet.write("Q" + str(row), tax_line.deductible_amount)
+        else:
+            sheet.write("Q" + str(row), 0.0)
         if tax_line.special_tax_id:
             map_vals = line.vat_book_id.get_special_taxes_dic()[
                 tax_line.special_tax_id.id

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -86,7 +86,7 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatVatBookBase):
         # P_IVA0_ND - 21% IVA Soportado no deducible
         line = vat_book.received_tax_summary_ids[2]
         self.assertAlmostEqual(line.base_amount, 100)
-        # self.assertAlmostEqual(line.tax_amount, 21)
+        self.assertAlmostEqual(line.tax_amount, 21)
         # Print to PDF
         report_pdf = self.env["ir.actions.report"]._render(
             "l10n_es_vat_book.act_report_vat_book_invoices_issued_pdf", vat_book.ids


### PR DESCRIPTION
Hola! 
He modificado el código para que funciona correcto con los impuestos de IVA soportado no deducible.
Podeis revisar por favor y si os parece correcto fusionar y seguir revisar el [PR#4311](https://github.com/OCA/l10n-spain/pull/4311)

Antes:
<img width="1524" height="477" alt="image" src="https://github.com/user-attachments/assets/6961911a-b300-4f52-a6bc-f9f360d17274" />

Después de cambios:
<img width="1454" height="351" alt="image" src="https://github.com/user-attachments/assets/5959f0f1-0220-44a3-b888-9fbd46477927" />
